### PR TITLE
Persist hosts throughout tests

### DIFF
--- a/lib/beaker-rspec.rb
+++ b/lib/beaker-rspec.rb
@@ -1,44 +1,7 @@
-require 'beaker'
-
 module BeakerRSpec
-  include Beaker::DSL
+  require 'beaker'
 
-  def logger
-    @logger
-  end
-
-  def options
-    @options
-  end
-
-  def config
-    @config
-  end
-
-  def provision
-    @network_manager = Beaker::NetworkManager.new(@options, @logger)
-    RSpec.configuration.hosts = @network_manager.provision
-  end
-
-  def validate
-    Beaker::Utils::Validator.validate(RSpec.configuration.hosts, @logger)
-  end
-
-  def setup(args = [])
-    @options_parser = Beaker::Options::Parser.new
-    @options = @options_parser.parse_args(args)
-    @options[:debug] = true
-    @logger = Beaker::Logger.new(@options)
-    @options[:logger] = @logger
-    RSpec.configuration.hosts = []
-  end
-
-  def hosts
-    RSpec.configuration.hosts
-  end
-
-  def cleanup
-    @network_manager.cleanup
-  end
+  require 'beaker-rspec/beaker_shim'
+  require 'beaker-rspec/spec_helper'
 
 end

--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -1,0 +1,46 @@
+require 'beaker'
+
+module BeakerRSpec
+  module BeakerShim
+    include Beaker::DSL
+
+    def logger
+      @logger
+    end
+
+    def options
+      @options
+    end
+
+    def config
+      @config
+    end
+
+    def provision
+      @network_manager = Beaker::NetworkManager.new(@options, @logger)
+      RSpec.configuration.hosts = @network_manager.provision
+    end
+
+    def validate
+      Beaker::Utils::Validator.validate(RSpec.configuration.hosts, @logger)
+    end
+
+    def setup(args = [])
+      @options_parser = Beaker::Options::Parser.new
+      @options = @options_parser.parse_args(args)
+      @options[:debug] = true
+      @logger = Beaker::Logger.new(@options)
+      @options[:logger] = @logger
+      RSpec.configuration.hosts = []
+    end
+
+    def hosts
+      RSpec.configuration.hosts
+    end
+
+    def cleanup
+      @network_manager.cleanup
+    end
+
+  end
+end

--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -1,0 +1,27 @@
+require 'beaker-rspec/beaker_shim'
+include BeakerRSpec::BeakerShim
+
+RSpec.configure do |c|
+  # Enable color
+  c.tty = true
+
+  # Define persistant hosts setting
+  c.add_setting :hosts, :default => []
+
+  # Defined target nodeset
+  nodeset = ENV['RSPEC_SET'] || 'default'
+  nodesetfile = ENV['RSPEC_SETFILE'] || File.join('spec/acceptance/nodesets',"#{nodeset}.yml")
+
+  preserve = ENV['RSPEC_DESTROY'] ? '--preserve-hosts' : ''
+  fresh_nodes = ENV['RSPEC_PROVISION'] ? '' : '--no-provision'
+
+  # Configure all nodes in nodeset
+  c.setup([preserve, fresh_nodes, '--type','git','--hosts', nodesetfile])
+  c.provision
+  c.validate
+
+  # Destroy nodes if no preserve hosts
+  c.after :suite do
+    c.cleanup
+  end
+end

--- a/sample.cfg
+++ b/sample.cfg
@@ -6,18 +6,18 @@ HOSTS:
       - dashboard
       - database
     platform: ubuntu-10.04-amd64
-    hypervisor : vagrant
+    hypervisor: vagrant
     box: ubuntu-server-10044-x64-vbox4210
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
-    ip : 192.168.20.20
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
+    ip: 192.168.20.20
   ubuntu-10-04-4-x64-agent:
     roles:
       - agent
     platform: ubuntu-10.04-amd64
-    hypervisor : vagrant
+    hypervisor: vagrant
     box: ubuntu-server-10044-x64-vbox4210
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
-    ip : 192.168.21.21
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
+    ip: 192.168.21.21
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,7 +1,0 @@
-module BeakerRSpec::Helpers
-  include Beaker::DSL
-
-  def hosts
-    self.class.hosts
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,30 +1,3 @@
-require 'beaker-rspec'
-require 'helpers'
+ENV['RSPEC_SETFILE'] = 'sample.cfg'
 
-include BeakerRSpec
-
-RSpec.configure do |c|
-  # Enable color
-  c.tty = true
-
-  # Define persistant hosts setting
-  c.add_setting :hosts
-
-  # System specific config
-  c.extend BeakerRSpec::Helpers #to allow dsl access outside tests
-
-  # Defined target nodeset
-  nodeset = ENV['RSPEC_SET'] || 'sample.cfg'
-  preserve = ENV['RSPEC_DESTROY'] ? '--preserve-hosts' : ''
-  fresh_nodes = ENV['RSPEC_PROVISION'] ? '' : '--no-provision'
-
-  # Configure all nodes in nodeset
-  c.setup([preserve, fresh_nodes, '--type','git','--hosts', nodeset])
-  c.provision
-  c.validate
-
-  # Destroy nodes if no preserve hosts
-  c.after :suite do
-    c.cleanup
-  end
-end
+require "beaker-rspec"


### PR DESCRIPTION
The spec helper initializes hosts before the test suite is begun. The
hosts array is assigned to an RSpec setting to persist access across
testing.
