### PR TITLE
(QE-243) beaker needs an easy way to get modules onto the SUTs

### DIFF
--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -42,5 +42,11 @@ module BeakerRSpec
       @network_manager.cleanup
     end
 
+    def puppet_module_install opts = {}
+      hosts.each do |host|
+        scp_to host, opts[:source], File.join(host['distmoduledir'], opts[:module_name])
+      end
+    end
+
   end
 end

--- a/sample.cfg
+++ b/sample.cfg
@@ -10,6 +10,7 @@ HOSTS:
     box: ubuntu-server-10044-x64-vbox4210
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
     ip: 192.168.20.20
+    distmoduledir: .
   ubuntu-10-04-4-x64-agent:
     roles:
       - agent
@@ -18,6 +19,7 @@ HOSTS:
     box: ubuntu-server-10044-x64-vbox4210
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210.box
     ip: 192.168.21.21
+    distmoduledir: .
 CONFIG:
   nfs_server: none
   consoleport: 443


### PR DESCRIPTION
- support the rspec-system style:
  puppet_module_install(:source => proj_root, :module_name =>
  'haproxy')
