### PR TITLE
(QE-362) simplified non-pe puppet installation

### DIFF
--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -4,6 +4,10 @@ module BeakerRSpec
   module BeakerShim
     include Beaker::DSL
 
+    CLONEDIR = "puppet"
+    HELPER = "puppet/acceptance/lib/helper.rb"
+    GITPRESUITE = "puppet/acceptance/config/el6/setup/git/pre-suite"
+
     def logger
       @logger
     end
@@ -14,6 +18,28 @@ module BeakerRSpec
 
     def config
       @config
+    end
+
+    def clone_puppet_acceptance
+      FileUtils.rm_rf(CLONEDIR)
+      FileUtils.mkdir_p(CLONEDIR)
+      Dir.chdir(CLONEDIR) do
+        system("git init")
+        system("git remote add puppet https://github.com/puppetlabs/puppet")
+        system("git config core.sparsecheckout true")
+        File.open('.git/info/sparse-checkout', 'a') { |f| f.write('acceptance') }
+        system("git pull puppet master")
+        system("git config core.sparsecheckout false")
+      end
+    end
+
+    def do_git_pre_test
+      clone_puppet_acceptance
+      require File.expand_path(HELPER)
+      @options[:pre_suite] = @options_parser.file_list([GITPRESUITE])
+      Beaker::TestSuite.new(
+        :pre_suite, @hosts, @options, "stop"
+      ).run_and_raise_on_failure
     end
 
     def provision


### PR DESCRIPTION
- add support for git installation
  - pull the appropriate pre-suite from puppetlabs/puppet
