### PR TITLE
Add serverspec support

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Testing dependencies
-  s.add_development_dependency 'rspec', '2.11.0'
+  s.add_development_dependency 'rspec', '2.13.0'
   s.add_development_dependency 'fakefs', '0.4'
+  s.add_development_dependency 'serverspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov' unless less_than_one_nine
 

--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -1,0 +1,56 @@
+require 'serverspec'
+require 'serverspec/backend/exec'
+
+module Serverspec
+  module Backend
+    class BeakerRSpec < Serverspec::Backend::Exec
+      def run_command(cmd, opt={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        ret = ssh_exec!(cmd)
+
+        if @example
+          @example.metadata[:command] = cmd
+          @example.metadata[:stdout]  = ret[:stdout]
+        end
+
+        ret
+      end
+
+      private
+      def ssh_exec!(command)
+        if @example and @example.metadata[:node]
+          node = @example.metadata[:node]
+        else
+          node = default
+        end
+
+        r = on node, command, { :acceptable_exit_codes => (0..127) }
+        {
+          :exit_status => r.exit_code,
+          :stdout      => r.stdout,
+          :stderr      => r.stderr
+        }
+      end
+    end
+  end
+end
+
+
+module Serverspec
+  module Helper
+    module BeakerRSpec
+      def backend(commands_object=nil)
+        if ! respond_to?(:commands)
+          commands_object = Serverspec::Commands::Base.new
+        end
+        instance = Serverspec::Backend::BeakerRSpec.instance
+        instance.set_commands(commands_object || commands)
+        instance
+      end
+    end
+  end
+end
+
+include Serverspec::Helper::BeakerRSpec
+include Serverspec::Helper::DetectOS

--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'beaker-rspec/beaker_shim'
+require "beaker-rspec/helpers/serverspec"
 include BeakerRSpec::BeakerShim
 
 RSpec.configure do |c|

--- a/spec/acceptance/example_spec.rb
+++ b/spec/acceptance/example_spec.rb
@@ -8,4 +8,10 @@ describe "ignore" do
     end
   end
 
+  hosts.each do |node|
+    describe service('ssh'), :node => node do
+      it { should be_running }
+      it { should be_enabled }
+    end
+  end
 end


### PR DESCRIPTION
This adds the ability for serverspec to run matcher commands on the hosts of beaker-rspec via calling the DSL commands on the given host.
