### PR TITLE
clearer naming for env var that controls provisioning

### DIFF
--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
   nodesetfile = ENV['RSPEC_SETFILE'] || File.join('spec/acceptance/nodesets',"#{nodeset}.yml")
 
   preserve = ENV['RSPEC_DESTROY'] ? '--preserve-hosts' : ''
-  fresh_nodes = ENV['RSPEC_PROVISION'] ? '' : '--no-provision'
+  fresh_nodes = ENV['RSPEC_NO_PROVISION'] ? '--no-provision' : ''
 
   # Configure all nodes in nodeset
   c.setup([preserve, fresh_nodes, '--type','git','--hosts', nodesetfile])


### PR DESCRIPTION
- use RSPEC_NO_PROVISION if you want to reuse nodes
