### PR TITLE
(QE-603) RSPEC_DESTROY and RSPEC_NO_PROVISION need to be clarified

### DIFF
--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -10,11 +10,11 @@ RSpec.configure do |c|
   c.add_setting :hosts, :default => []
 
   # Defined target nodeset
-  nodeset = ENV['RSPEC_SET'] || 'default'
-  nodesetfile = ENV['RSPEC_SETFILE'] || File.join('spec/acceptance/nodesets',"#{nodeset}.yml")
+  nodeset = ENV['RS_SET'] || 'default'
+  nodesetfile = ENV['RS_SETFILE'] || File.join('spec/acceptance/nodesets',"#{nodeset}.yml")
 
-  preserve = ENV['RSPEC_DESTROY'] ? '--preserve-hosts' : ''
-  fresh_nodes = ENV['RSPEC_NO_PROVISION'] ? '--no-provision' : ''
+  preserve = ENV['RS_DESTROY'] == 'no' ? '--preserve-hosts' : ''
+  fresh_nodes = ENV['RS_PROVISION'] == 'no' ? '--no-provision' : ''
 
   # Configure all nodes in nodeset
   c.setup([preserve, fresh_nodes, '--type','git','--hosts', nodesetfile])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
-ENV['RSPEC_SETFILE'] = 'sample.cfg'
+ENV['RS_SETFILE'] = 'sample.cfg'
 
 require "beaker-rspec"


### PR DESCRIPTION
- using RS_DESTROY=no for not destroying boxes post-test
- using RS_PROVISION=no for not provisioning boxes before tests
