### PR TITLE
create 2.0.0 beaker-rspec gem

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -6,7 +6,7 @@ less_than_one_nine = ruby_conf['MAJOR'].to_i == 1 && ruby_conf['MINOR'].to_i < 9
 
 Gem::Specification.new do |s|
   s.name        = "beaker-rspec"
-  s.version     = '1.0.0'
+  s.version     = '2.0.0'
   s.authors     = ["Puppetlabs"]
   s.email       = ["sqa@puppetlabs.com"]
   s.homepage    = "https://github.com/puppetlabs/beaker-rspec"


### PR DESCRIPTION
- upping to 2.0.0 because of change in ENV var support
