### PR TITLE
specinfra 0.5.0 has made some changes that break run_command for us,

### DIFF
--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -26,7 +26,7 @@ module SpecInfra
           @example.metadata[:stdout]  = ret[:stdout]
         end
 
-        ret
+        CommandResult.new ret
       end
 
       private


### PR DESCRIPTION
get the ret from CommandResult.new now.
