### PR TITLE
update configuration/validation steps for beaker 1.8.1+ gem

### DIFF
--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -29,10 +29,18 @@ module BeakerRSpec
       RSpec.configuration.hosts = @network_manager.provision
     end
 
-    # Validate that the SUTs are up and correctly configured
+    # Validate that the SUTs are up and correctly configured.  Checks that required
+    # packages are installed and if they are missing attempt installation.
     # Assumes #setup and #provision has already been called.
     def validate
-      Beaker::Utils::Validator.validate(RSpec.configuration.hosts, @logger)
+      @network_manager.validate
+    end
+
+    # Run configuration steps to have hosts ready to test on (such as ensuring that 
+    # hosts are correctly time synched, adding keys, etc).
+    # Assumes #setup, #provision and #validate have already been called.
+    def configure
+      @network_manager.configure
     end
 
     # Setup the testing environment

--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -37,6 +37,7 @@ RSpec.configure do |c|
   c.setup([fresh_nodes, '--hosts', nodesetfile, keyfile, debug].flatten.compact)
   c.provision
   c.validate
+  c.configure
 
   # Destroy nodes if no preserve hosts
   c.after :suite do


### PR DESCRIPTION
- beaker has changed its configuration/validation steps and beaker-rspec
  will need to be updated as well
- these changes will need to be run with beaker 1.8.1+
