### PR TITLE
Unpin rspec

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 4.0'
   s.add_development_dependency 'fakefs', '0.4'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'simplecov' unless less_than_one_nine
 
   # Documentation dependencies
@@ -33,7 +34,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'beaker', '~> 1.10'
-  s.add_runtime_dependency 'rspec', '~> 2.14'
+  s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'serverspec', '~> 1.0'
   s.add_runtime_dependency 'specinfra', '~> 1.0'
 end


### PR DESCRIPTION
rspec 2.x is a development dependency, but the runtime dependency shouldn't pin to any specific version as the beaker-rspec library doesn't care.
