### PR TITLE
Remove development dependency

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 4.0'
   s.add_development_dependency 'fakefs', '0.4'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'simplecov' unless less_than_one_nine
 
   # Documentation dependencies


### PR DESCRIPTION
Beaker-rspec's tests are already compatible with rspec 3, so no need to
update the specs for the latest rspec
