### PR TITLE
(QENG-833) beaker-rspec broken when using beaker 1.13

### DIFF
--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -12,7 +12,7 @@ module BeakerRSpec
     # Accessor for logger
     # @return Beaker::Logger object
     def logger
-      @logger
+      RSpec.configuration.logger
     end
 
     # Accessor for options hash
@@ -50,8 +50,8 @@ module BeakerRSpec
       options_parser = Beaker::Options::Parser.new
       options = options_parser.parse_args(args)
       options[:debug] = true
-      @logger = Beaker::Logger.new(options)
-      options[:logger] = @logger
+      RSpec.configuration.logger = Beaker::Logger.new(options)
+      options[:logger] = logger
       RSpec.configuration.hosts = []
       RSpec.configuration.options = options
     end

--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -10,6 +10,8 @@ RSpec.configure do |c|
   c.add_setting :hosts, :default => []
   # Define persistant options setting
   c.add_setting :options, :default => {}
+  # Define persistant logger object
+  c.add_setting :logger, :default => nil
 
   #default option values
   defaults = {

--- a/spec/acceptance/example_spec.rb
+++ b/spec/acceptance/example_spec.rb
@@ -12,6 +12,11 @@ describe "ignore" do
     install_pe
   end
 
+  example "access the logger" do
+     logger.debug("hi, i'm a debug message")
+     logger.notify("hi, I'm a notify message")
+  end
+
   hosts.each do |node|
     describe service('ssh'), :node => node do
       it { should be_running }


### PR DESCRIPTION
- ensure that the logger object is available
