### PR TITLE
 (BKR-467) beaker-rspec does not correctly update os when cycling through hosts

### DIFF
--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -61,6 +61,17 @@ module Specinfra
 end
 
 module Specinfra::Helper::Os
+
+  @@known_nodes = {}
+
+  def os
+    working_node_name = get_working_node.to_s
+    if !@@known_nodes[working_node_name] # haven't seen this yet, better detect the os
+      @@known_nodes[working_node_name] = property[:os] = detect_os
+    end
+    @@known_nodes[working_node_name]
+  end
+
   private
 
   # Override detect_os to look at the node platform, short circuit discoverability
@@ -265,7 +276,7 @@ module Specinfra::Backend
     def build_command(cmd)
       useshell = '/bin/sh'
       cmd = cmd.shelljoin if cmd.is_a?(Array)
-      cmd = "#{useshell.shellescape} -c #{cmd.shellescape}"
+      cmd = "#{String(useshell).shellescape} -c \"#{String(cmd)}\""
 
       path = Specinfra.configuration.path
       if path

--- a/spec/acceptance/example_spec.rb
+++ b/spec/acceptance/example_spec.rb
@@ -32,7 +32,7 @@ describe "ignore" do
   context "has serverspec support" do
     hosts.each do |node|
       sshd = case node['platform']
-             when /windows|el-|redhat|centos|debian/
+             when /windows|el-|redhat|centos/
                'sshd'
              else
                'ssh'


### PR DESCRIPTION
- found that beaker was unable to complete its acceptance tests when
  provided with multiple SUTs of multiple os types in the same hosts
  file
- need to correctly detectos when we switch to a new os, otherwise we
  assume that we are executing on the same os and generate the wrong
  command strings
- keeps a hash of known hosts associated with their os type so that we
  don't have to run detect_os (which can be somewhat time expensive)
  more than once per-SUT