### PR TITLE
Enable the proxy feature available in beaker cli.

### DIFF
--- a/lib/beaker-rspec/beaker_shim.rb
+++ b/lib/beaker-rspec/beaker_shim.rb
@@ -33,6 +33,7 @@ module BeakerRSpec
     def provision
       @network_manager = Beaker::NetworkManager.new(options, @logger)
       RSpec.configuration.hosts = @network_manager.provision
+      @network_manager.proxy_package_manager
     end
 
     # Validate that the SUTs are up and correctly configured.  Checks that required
@@ -42,7 +43,7 @@ module BeakerRSpec
       @network_manager.validate
     end
 
-    # Run configuration steps to have hosts ready to test on (such as ensuring that 
+    # Run configuration steps to have hosts ready to test on (such as ensuring that
     # hosts are correctly time synched, adding keys, etc).
     # Assumes #setup, #provision and #validate have already been called.
     def configure


### PR DESCRIPTION
Improves acceptance testing performance and lowers network traffic to package
respositories with beaker-rspec.

Running a suitably configured proxy cache to act as a package cache, add the
following nodeset configuration.

```
---
CONFIG:
  package_proxy: http://<proxy_addr>:<proxy_port>
```

Beaker supports Debian (APT) and RHEL/Centos (RPM) based package proxies out of the box. See beaker --help (package-proxy) for further details.

Example, Squid is a suitable local package cache,

squid.conf
```
mum_object_size 100 MB
cache_replacement_policy heap LFUDA
refresh_pattern ^ftp:          1440    20%     10080
refresh_pattern ^gopher:       1440    0%      1440
refresh_pattern Packages\.bz2$ 0       20%     4320 refresh-ims
refresh_pattern Sources\.bz2$  0       20%     4320 refresh-ims
refresh_pattern Release\.gpg$  0       20%     4320 refresh-ims
refresh_pattern Release$       0       20%     4320 refresh-ims
refresh_pattern .              0       20%     4320
```