### PR TITLE
(BKR-474) Missing shellescape in /helpers/serverspec.rb since a6b3e503

### DIFF
--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -276,7 +276,7 @@ module Specinfra::Backend
     def build_command(cmd)
       useshell = '/bin/sh'
       cmd = cmd.shelljoin if cmd.is_a?(Array)
-      cmd = "#{String(useshell).shellescape} -c \"#{String(cmd)}\""
+      cmd = "#{String(useshell).shellescape} -c #{String(cmd).shellescape}"
 
       path = Specinfra.configuration.path
       if path


### PR DESCRIPTION
- put the shellescape back in
- tested green locally on osx/windows/ubuntu/centos/debian