### PR TITLE
Add a check on windows part, to exec commands on a non cygwin environment

### DIFF
--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -235,10 +235,18 @@ module Specinfra::Backend
     def run_command(cmd, opt = {})
       node = get_working_node
       script = create_script(cmd)
-      on node, "rm -f script.ps1"
+      delete_command = "rm -f script.ps1"
+      redirection = "< /dev/null"
+      #if node is not cygwin rm will fail...
+      #There should be a better way to do this, but for now , this works
+      if not node.is_cygwin?
+          delete_command = "del script.ps1"
+          redirection = "< NUL "
+      end
+      on node, delete_command
       create_remote_file(node, 'script.ps1', script)
       # cygwin support /dev/null, if running from winrm would use < NULL
-      ret = ssh_exec!(node, "powershell.exe -File script.ps1 < /dev/null")
+      ret = ssh_exec!(node, "powershell.exe -File script.ps1 #{redirection}")
 
       if @example
         @example.metadata[:command] = script


### PR DESCRIPTION
When a PSwindows  node neither rm nor /dev/null will work. This is a way to fix this (probably not the best one...)