### PR TITLE
Fix example spec file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ describe 'mysql::server::account_security class' do
   }
 
   it 'should run without errors' do
-    result = apply_manifest(manifest)
+    result = apply_manifest(manifest, :catch_failures => true)
     expect(@result.exit_code).to eq 2
   end
 
@@ -137,7 +137,7 @@ describe 'mysql::server::account_security class' do
   end
 
   it 'should run a second time without changes' do
-    result = apply_manifest(manifest)
+    result = apply_manifest(manifest, :catch_failures => true)
     expect(@result.exit_code).to eq 0
   end
 


### PR DESCRIPTION
While following this example, I needed this change to get the tests to pass.

[The documentation for beaker](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker%2FDSL%2FHelpers%2FPuppetHelpers%3Aapply_manifest_on) explains why:

> `:catch_failures` (Boolean) — default: `false` — By default `puppet -apply` will exit with 0, which does not count as a test failure, even if there were errors or changes when applying the manifest. This option enables detailed exit codes and causes a test failure if `puppet -apply` indicates there was a failure during its execution.