### PR TITLE
(MAINT) pinning specinfra to pass testing

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'beaker', '~> 2.0'
   s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'serverspec', '~> 2'
-  s.add_runtime_dependency 'specinfra', '~> 2'
+  s.add_runtime_dependency 'specinfra', '= 2.59.0'
 end


### PR DESCRIPTION
Specinfra's newer versions (>=2.59.1) inspect classes and use
their name method. Hocon shadows the class.name method, and
breaks as such. There's a separate issue to fix the hocon
problem (https://github.com/puppetlabs/ruby-hocon/issues/75).
specinfra has decided to not use the name method either
(https://github.com/mizzy/specinfra/pull/561).
Once that's merged & released, this should be reverted.