### PR TITLE
(BKR-946) update beaker dependency & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 beaker-rspec is a bridge between the puppet acceptance test harness ([beaker](https://github.com/puppetlabs/beaker)) and [rspec](https://github.com/rspec/rspec). It also integrates [serverspec](http://serverspec.org/).
 
+#Upgrading from beaker-rspec 5 to 6
+
+In beaker-rspec 6, we've picked up the newest beaker, 3.y. In this release, we've
+given up support for Ruby 1.9 and moved to 2.2.5 as our lowest tested version,
+as well as a number of other changes underneath.
+
+To learn more about those changes, please checkout our
+[how-to upgrade](https://github.com/puppetlabs/beaker/blob/master/docs/how_to/upgrade_from_2_to_3.md)
+doc. Note that besides the Ruby version & beaker dependency change, nothing else
+was changed in beaker-rspec itself.
+
 #Typical Workflow
 
 Beaker does setup and provision all nodes from your nodeset on each test run, and cleans up the VMs after use. During development on a module it can be very handy to keep the VMs available for inspection or reuse. Set `BEAKER_destroy=no` do skip the cleanup and `BEAKER_provision=no` once the VMs are created.

--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -1,10 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require 'rbconfig'
 require 'beaker-rspec/version'
-
-ruby_conf = defined?(RbConfig) ? RbConfig::CONFIG : Config::CONFIG
-less_than_one_nine = ruby_conf['MAJOR'].to_i == 1 && ruby_conf['MINOR'].to_i < 9
 
 Gem::Specification.new do |s|
   s.name        = "beaker-rspec"
@@ -16,6 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q{RSpec bindings for beaker, see https://github.com/puppetlabs/beaker}
   s.license     = 'Apache2'
 
+  s.required_ruby_version = Gem::Requirement.new('>= 2.2.5')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
@@ -26,15 +23,13 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'fakefs', '~> 0.6'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov' unless less_than_one_nine
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown' unless less_than_one_nine
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '~> 2.0'
+  s.add_runtime_dependency 'beaker', '~> 3.0'
   s.add_runtime_dependency 'rspec'
   s.add_runtime_dependency 'serverspec', '~> 2'
   s.add_runtime_dependency 'specinfra', '~> 2'


### PR DESCRIPTION
This change picks up from the [branch](https://github.com/puppetlabs/beaker-rspec/commit/849e4e226c9970cfeea78064967d02e7bc20b152) that we've been testing over the last few weeks and adds documentation & the new Ruby requirement to it.