### PR TITLE
Bkr 1115 Allow options-file to be configured via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#beaker-rspec
+# beaker-rspec
 
 beaker-rspec is a bridge between the puppet acceptance test harness ([beaker](https://github.com/puppetlabs/beaker)) and [rspec](https://github.com/rspec/rspec). It also integrates [serverspec](http://serverspec.org/).
 
-#Upgrading from beaker-rspec 5 to 6
+# Upgrading from beaker-rspec 5 to 6
 
 In beaker-rspec 6, we've picked up the newest beaker, 3.y. In this release, we've
 given up support for Ruby 1.9 and moved to 2.2.5 as our lowest tested version,
@@ -13,7 +13,7 @@ To learn more about those changes, please checkout our
 doc. Note that besides the Ruby version & beaker dependency change, nothing else
 was changed in beaker-rspec itself.
 
-#Typical Workflow
+# Typical Workflow
 
 Beaker does setup and provision all nodes from your nodeset on each test run, and cleans up the VMs after use. During development on a module it can be very handy to keep the VMs available for inspection or reuse. Set `BEAKER_destroy=no` do skip the cleanup and `BEAKER_provision=no` once the VMs are created.
 
@@ -31,7 +31,7 @@ Beaker does setup and provision all nodes from your nodeset on each test run, an
 
         cd .vagrant/beaker_vagrant_files/default.yml ; vagrant destroy --force
 
-##Supported ENV variables
+## Supported ENV variables
 
 * `BEAKER_color`: set to `no` to disable color output
 * `BEAKER_debug`: set to any value to enable beaker debug logging
@@ -44,16 +44,16 @@ Beaker does setup and provision all nodes from your nodeset on each test run, an
 
 For details on the specific mappings, the [setup code](https://github.com/puppetlabs/beaker-rspec/blob/2771b4b1864692690254a969680a57ff22ac0516/lib/beaker-rspec/spec_helper.rb#L26-L32) and the [beaker docs](https://github.com/puppetlabs/beaker/blob/master/docs/tutorials/the_command_line.md).
 
-#Building your Module Testing Environment
+# Building your Module Testing Environment
 
 Using puppetlabs-mysql as an example module.
 
-##Clone the module repository of the module where you want to add tests
+## Clone the module repository of the module where you want to add tests
 
     git clone https://github.com/puppetlabs/puppetlabs-mysql
     cd puppetlabs-mysql
 
-##Install beaker-rspec
+## Install beaker-rspec
 
 In module's top level directory edit the Gemfile. You should see a `:system_tests`
 or `:acceptance` group there, but if not, add beaker-rspec there:
@@ -68,7 +68,7 @@ Then run
 
     bundle install
 
-##Create node files
+## Create node files
 
 These files indicate the nodes (or hosts) that the tests will be run on.  By default, any node file called `default.yml` will be used.  You can override this using the `BEAKER_set` environment variable to indicate an alternate file.  Do not provide full path or the '.yml' file extension to `BEAKER_set`, it is assumed to be located in 'spec/acceptance/nodesets/${NAME}.yml' by beaker-rspec.  If you wish to use a completely different file location use `BEAKER_setfile` and set it to the full path (including file extension) of your hosts file.
 
@@ -84,7 +84,7 @@ Create the nodesets directory.  From module's top level directory:
 
 Copy any nodesets that you wish to use into the nodesets directory.
 
-##Create the spec_helper_acceptance.rb
+## Create the spec_helper_acceptance.rb
 
 In the `spec` folder, you should see the project's `spec_helper_acceptance.rb`.
 This file contains all of the setup logic needed to get your Systems Under Test
@@ -134,7 +134,7 @@ This method will install the latest puppet-agent from the specified
 
 Update spec_helper_acceptance.rb to reflect the module under test.  You will need to set the correct module name and add any module dependencies.  Place the file in the `spec` directory (in this case `puppetlabs-mysql/spec`)
 
-##Create spec tests for your module
+## Create spec tests for your module
 
 Spec tests are written in [RSpec](http://rspec.info). You can also use [serverspec](http://serverspec.org/) matchers to test [resources](http://serverspec.org/resource_types.html).
 
@@ -179,7 +179,7 @@ describe 'mysql::server::account_security class' do
 end
 ```
 
-##Run your spec tests
+## Run your spec tests
 
 From module's top level directory
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Beaker does setup and provision all nodes from your nodeset on each test run, an
 * `BEAKER_debug`: set to any value to enable beaker debug logging
 * `BEAKER_destroy`: set to `no` to keep the VMs after the test run. Set to `onpass` to keep the VMs around only after a test failure.
 * `BEAKER_keyfile`: specify alternate SSH key to access the test VMs
+* `BEAKER_options_file`: set to the file path of the options file to be used as the default options for beaker.  Equivalent to the `--options-file` parameter.  
 * `BEAKER_provision`: set to `no` to skip provisioning boxes before testing, beaker will then assume that boxes are already provisioned and reachable
 * `BEAKER_set`: set to the name of the node file to be used during testing (exclude .yml file extension, it will be added by beaker-rspec). The file is assumed to be in module's spec/acceptance/nodesets directory.
 * `BEAKER_setfile` - set to the full path to a node file be used during testing (be sure to include full path and file extensions, beaker-rspec will use this path without editing/altering it in any way)

--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -30,9 +30,10 @@ RSpec.configure do |c|
     :keyfile     => ENV['BEAKER_keyfile'] || ENV['RS_KEYFILE'],
     :debug       => ENV['BEAKER_debug'] || ENV['RS_DEBUG'],
     :destroy     => ENV['BEAKER_destroy'] || ENV['RS_DESTROY'],
-  }.delete_if {|key, value| value.nil?}
-  #combine defaults and env_vars to determine overall options
-  options = defaults.merge(env_vars)
+    :optionsfile => ENV['BEAKER_options_file'] || ENV['RS_OPTIONS_FILE'],
+   }.delete_if {|key, value| value.nil?}
+   #combine defaults and env_vars to determine overall options
+   options = defaults.merge(env_vars)
 
   # process options to construct beaker command string
   nodesetfile = options[:nodesetfile] || File.join('spec/acceptance/nodesets',"#{options[:nodeset]}.yml")
@@ -40,9 +41,10 @@ RSpec.configure do |c|
   keyfile = options[:keyfile] ? ['--keyfile', options[:keyfile]] : nil
   debug = options[:debug] ? ['--log-level', 'debug'] : nil
   color = options[:color] == 'no' ? ['--no-color'] : nil
+  options_file = options[:optionsfile] ? ['--options-file',options[:optionsfile]] || nil
 
   # Configure all nodes in nodeset
-  c.setup([fresh_nodes, '--hosts', nodesetfile, keyfile, debug, color].flatten.compact)
+  c.setup([fresh_nodes, '--hosts', nodesetfile, keyfile, debug, color, options_file]).flatten.compact)
   c.provision
   c.validate
   c.configure


### PR DESCRIPTION
In order to run beaker acceptance tests unmodified behind a proxy, the host_env configuration needs to be externally settable (i.e. outside of the tests).   As this is passed in to beaker via the `--options-file`, it makes (made?) sense to use expose this runtime parameter.

When used in conjunction with [BKR-1114 pull request](https://github.com/puppetlabs/beaker/pull/1387), it is possible to do the following:

    git clone https://github.com/puppetlabs/puppetlabs-inifile.git
    cd puppetlabs-inifile
    export BEAKER_options_file=~/beaker-proxy.cfg
    export DOCKER_BUILDARGS="HTTP_PROXY=http://10.0.2.2:3128/ HTTPS_PROXY=http://10.0.2.2:3128/     http_proxy=http://10.0.2.2:3128/       https_proxy=http://10.0.2.2:3128/"
    PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7   bundle exec rake -v beaker

Where `~/beaker-config.cfg` contains:

    {
      :package_proxy => 'http://10.0.2.2:3128/', 
      :host_env => {
        "http_proxy" => "http://10.0.2.2:3128/",
        "https_proxy" => "http://10.0.2.2:3128/",
        "HTTP_PROXY" => "http://10.0.2.2:3128/",
        "HTTPS_PROXY" => "http://10.0.2.2:3128/"
      }
    }

