### PR TITLE
(maint) - Bumping Beaker dependency as it is limited to Beaker v3 and Beaker v4 has been released.

### DIFF
--- a/beaker-rspec.gemspec
+++ b/beaker-rspec.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   end
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '~> 3.0'
+  s.add_runtime_dependency 'beaker', '~> 4.0'
   s.add_runtime_dependency 'rspec', '~> 3.0'
   s.add_runtime_dependency 'serverspec', '~> 2'
   s.add_runtime_dependency 'specinfra', '~> 2'


### PR DESCRIPTION
As Beaker v 4.0.0 has been released this is being pinned to Beaker v3. Bump required to make use of latest version of Beaker and to avoid dependency breakages.