### PR TITLE
Rearrange the cleanup handling

### DIFF
--- a/lib/beaker-rspec/spec_helper.rb
+++ b/lib/beaker-rspec/spec_helper.rb
@@ -47,14 +47,23 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.setup([fresh_nodes, '--hosts', nodesetfile, keyfile, debug, color, options_file].flatten.compact)
-  c.provision
-  c.validate
-  c.configure
 
   trap "SIGINT" do
     c.cleanup
     exit!(1)
   end
+
+  begin
+    c.provision
+  rescue StandardError => e
+    logger.error(e)
+    logger.info(e.backtrace)
+    c.cleanup
+    exit!(1)
+  end
+
+  c.validate
+  c.configure
 
   # Destroy nodes if no preserve hosts
   c.after :suite do


### PR DESCRIPTION
This patch moves the INT trap above the system provisioning as well as
wrapping the call to `provision` in a rescue block that will avoid
further execution.

This should fix the issue where container and local VM tests continue to
try and run the `provision` stage in the background even if the user
wants to cancel all jobs.

Cloud providers may need to address the issue in their `cleanup` method
specifically.