### PR TITLE
CI: switch from CentOS 8 -> CentOS 9

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,3 @@
-ENV['RS_SETFILE'] ||= 'centos8-64'
+ENV['RS_SETFILE'] ||= 'centos9-64'
 
 require 'beaker-rspec'


### PR DESCRIPTION
CentOS 8 is EoL and the mirrors are dead. We need to switch the OS to get a working pipeline again.