### PR TITLE
Use the backend variable inside the loop

### DIFF
--- a/lib/beaker-rspec/helpers/serverspec.rb
+++ b/lib/beaker-rspec/helpers/serverspec.rb
@@ -79,7 +79,7 @@ module Specinfra::Helper::Os
     Specinfra::Helper::DetectOs.subclasses.each do |c|
       res = c.detect
       if res
-        res[:arch] ||= Specinfra.backend.run_command('uname -m').stdout.strip
+        res[:arch] ||= backend.run_command('uname -m').stdout.strip
         return res
       end
     end


### PR DESCRIPTION
The variable Specinfra.backend was defined before the loop but then it's not used inside of the loop.